### PR TITLE
changes in readme. Faulty for loop issue in forecasts list.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,10 +41,10 @@ Examples
 
     forecasts = location.forecast()
     for forecast in forecasts:
-        print(forecasts.text())
-        print(forecasts.date())
-        print(forecasts.high())
-        print(forecasts.low())
+        print(forecast.text())
+        print(forecast.date())
+        print(forecast.high())
+        print(forecast.low())
 
 .. _API documentation: https://developer.yahoo.com/weather/
 


### PR DESCRIPTION
Most probably typo, but forecasts.text() must be forecast.text()
-------- error ---------(for reference)
Traceback (most recent call last):
  File "something.py", line 'some-number', in <module>
    print(forecasts.text())
AttributeError: 'list' object has no attribute 'text' 
--------end of error message----------